### PR TITLE
Maybe a little bug fixed

### DIFF
--- a/pdfminer/utils.py
+++ b/pdfminer/utils.py
@@ -213,7 +213,7 @@ PDFDocEncoding = ''.join( chr(x) for x in (
 ))
 def decode_text(s):
     """Decodes a PDFDocEncoding string to Unicode."""
-    if s.startswith('\xfe\xff'):
+    if s.startswith(b'\xfe\xff'):
         return str(s[2:], 'utf-16be', 'ignore')
     else:
         return ''.join( PDFDocEncoding[ord(c)] for c in s )


### PR DESCRIPTION
As files pdfminer reads are in byte mode, so here varible s is type of bytes and the startswith function is bytes.startswith instead of str.startswith, so there should be an "b" before '\xfe\xff', or TypeError will be raised.